### PR TITLE
RXR-188: Add remote location for PKPDsim

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,4 +11,6 @@ License: MIT + file LICENSE
 Depends: dplyr, utils, stats
 Imports: mvtnorm, PKPDsim, bbmle, optimx
 Suggests: testit
+Remotes:
+    InsightRX/PKPDsim2
 RoxygenNote: 7.0.2


### PR DESCRIPTION
Adds remote location for PKPDsim, allowing `remotes::install_github()` to find that dependency. To confirm this works:

``` r
remove.packages("PKPDsim")
#> Removing package from '/Library/Frameworks/R.framework/Versions/4.0/Resources/library'
#> (as 'lib' is unspecified)
library("PKPDsim") # ensure we don't have PKPDsim -- this should error
#> Error in library("PKPDsim"): there is no package called 'PKPDsim'
remotes::install_github("InsightRX/PKPDmap@RXR-188-add-remotes")
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo InsightRX/PKPDmap@RXR-188-add-remotes
#> PKPDsim (NA -> 40684e8e0...) [GitHub]
#> Downloading GitHub repo InsightRX/PKPDsim2@HEAD
#> 
#>      checking for file ‘/private/var/folders/1j/lz13jg2d4vgfmrbyjthf8_2w0000gn/T/RtmpPTp1Ew/remotes1c801e97e8fa/InsightRX-PKPDsim2-40684e8e048b578cd3de28a4f451da344b400971/DESCRIPTION’ ...  ✔  checking for file ‘/private/var/folders/1j/lz13jg2d4vgfmrbyjthf8_2w0000gn/T/RtmpPTp1Ew/remotes1c801e97e8fa/InsightRX-PKPDsim2-40684e8e048b578cd3de28a4f451da344b400971/DESCRIPTION’
#>   ─  preparing ‘PKPDsim’:
#>      checking DESCRIPTION meta-information ...  ✔  checking DESCRIPTION meta-information
#>   ─  cleaning src
#>   ─  checking for LF line-endings in source and make files and shell scripts
#>   ─  checking for empty or unneeded directories
#>   ─  building ‘PKPDsim_1.0.118.tar.gz’
#>      
#> 
#> Skipping install of 'PKPDsim' from a github remote, the SHA1 (40684e8e) has not changed since last install.
#>   Use `force = TRUE` to force installation
#>      checking for file ‘/private/var/folders/1j/lz13jg2d4vgfmrbyjthf8_2w0000gn/T/RtmpPTp1Ew/remotes1c806c162a02/InsightRX-PKPDmap-7b43b2148d166017ad4ee3c80f25e8321dcb43be/DESCRIPTION’ ...  ✔  checking for file ‘/private/var/folders/1j/lz13jg2d4vgfmrbyjthf8_2w0000gn/T/RtmpPTp1Ew/remotes1c806c162a02/InsightRX-PKPDmap-7b43b2148d166017ad4ee3c80f25e8321dcb43be/DESCRIPTION’
#>   ─  preparing ‘PKPDmap’:
#>      checking DESCRIPTION meta-information ...  ✔  checking DESCRIPTION meta-information
#>   ─  checking for LF line-endings in source and make files and shell scripts
#>   ─  checking for empty or unneeded directories
#>   ─  building ‘PKPDmap_0.37.tar.gz’
#>      
#> 
library("PKPDsim")
```

<sup>Created on 2021-03-24 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>
This should not affect anything in the Jenkins builds because a) the dependencies are already installed in the correct order, and b) I checked and R CMD Install does not use the `Remotes:` field to find dependencies (I guess it's just used by packages like remotes & devtools).