### PR TITLE
Bump version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PKPDmap
 Type: Package
 Title: MAP Bayesian estimates
-Version: 0.41
+Version: 0.53
 Date: 2021-03-31
 Author: Ron Keizer
 Maintainer: Ron Keizer <ron@insight-rx.com>


### PR DESCRIPTION
This increases the version number to higher than it was before changes were reverted in #18. Hopefully this will fix the fact that RSPM isn't showing the current version.