### PR TITLE
Ensure class check has length 1

### DIFF
--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -190,7 +190,7 @@ get_map_estimates <- function(
   }
   fix <- NULL
 
-  if(class(omega) == "matrix") {
+  if(inherits(omega, "matrix")) {
     omega_full <- omega # dummy om matrix
   } else {
     omega_full <-  PKPDsim::triangle_to_full(omega) # dummy om matrix


### PR DESCRIPTION
This is one of the places that causes `devtools::check()` to fail on downstream packages; `omega` can have multiple classes
<img width="224" alt="Screen Shot 2021-08-25 at 12 44 04 PM" src="https://user-images.githubusercontent.com/4452678/130854718-47d075f4-f391-42c0-99f5-63d6a05ff508.png">
