### PR TITLE
RXR-496: Fix misplaced parenthesis in get_map_estimates()

### DIFF
--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -483,7 +483,7 @@ get_map_estimates <- function(
     obj$res <- (transf(y) - transf(pred))
     obj$weights <- c(rep(0, length(data_before_init$t)), weights)
     obj$wres <- (obj$res / w_pred) * obj$weights
-    obj$cwres <- obj$res / sqrt(abs(cov(transf(pred), transf(y_orig)))) * c(rep(0, nrow(data_before_init), obj$weights))
+    obj$cwres <- obj$res / sqrt(abs(cov(transf(pred), transf(y_orig)))) * c(rep(0, nrow(data_before_init)), obj$weights)
     # Note: in NONMEM CWRES is on the population level, so can't really compare. NONMEM calls this CIWRES, it seems.
     obj$ires <- (transf(y_orig) - transf(ipred))
     obj$iwres <- (obj$ires / w_ipred)


### PR DESCRIPTION
Repeats 0 for each row in `data_before_init`, then appends `obj$weights`. I believe this was the original intent.