### PR TITLE
return mahalanobis calculations to get_map_estimates

### DIFF
--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -505,6 +505,7 @@ get_map_estimates <- function(
     warning("Var-cov matrix of MAP estimate not positive-definite, returning original `omega` instead.")
   }
   obj$vcov <- obj$vcov_full[t(!upper.tri(obj$vcov_full))]
+  obj$mahalanobis <- get_mahalanobis(y, ipred, w_ipred, ltbs)
   class(obj) <- c(class(obj), "map_estimates")
   return(obj)
 }

--- a/tests/test_MAP_est.R
+++ b/tests/test_MAP_est.R
@@ -95,6 +95,7 @@ assert("check fixing parameters #2",
 
 assert("check fixing parameters #2",
        tmp3$parameters$V2 == 50 && tmp3$parameters$Q == 3)
+assert("mahalanobis distance returned", !is.null(tmp3$mahalanobis))
 
 tmp4 <- get_map_estimates(parameters = par2,
                           model = model2,
@@ -195,3 +196,4 @@ fit1 <- get_map_estimates(model = model,
                           A_init = c(obs$y * par$V/1000),
                           residuals = T)
 assert("observations before first dose are also returned in fit object", all(round(fit1$ipred,5) == c(29.31226, 0.74833, 31.8271, 32.39943)))
+


### PR DESCRIPTION
We used to calculate and export the mahalanobis distance but it was accidentally removed in this commit: https://github.com/InsightRX/PKPDmap/commit/3fe2f2c0406d126ba82f4f995072cceb62afafa4

This PR adds it back in (unit tests expecting this were failing in irxanalytics, although we don't use it in insightrxr)