### PR TITLE
RXR-26666: fix preds and residuals for mixture model + test

### DIFF
--- a/PKPDmap.Rproj
+++ b/PKPDmap.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 42e31d31-a19a-49a8-abcd-daac065467eb
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -505,10 +505,13 @@ get_map_estimates <- function(
       A_init_ipred <- A_init
     }
     suppressMessages({
+      ## After fitting individual parameters, don't pass the mixture group to the simulator 
+      ## (so `mixture=NULL`), otherwise `sim()` will use the population value for the 
+      ## specified group, and not the individual fitted parameter.
       sim_ipred <- PKPDsim::sim_ode(
         ode = model,
         parameters = par,
-        mixture_group = mixture_group,
+        mixture_group = NULL,
         covariates = covariates,
         n_ind = 1,
         int_step_size = int_step_size,
@@ -528,7 +531,7 @@ get_map_estimates <- function(
       sim_pred <- PKPDsim::sim_ode(
         ode = model,
         parameters = parameters,
-        mixture_group = mixture_group,
+        mixture_group = NULL,
         covariates = covariates,
         n_ind = 1,
         int_step_size = int_step_size,

--- a/tests/testthat/test_get_map_estimates.R
+++ b/tests/testthat/test_get_map_estimates.R
@@ -641,7 +641,8 @@ test_that("Can estimate mixture model", {
     regimen = PKPDsim::new_regimen(amt = 100000, times=c(0, 24), type="bolus"),
     omega = omega,
     error = list(prop = 0, add = sqrt(1.73E+04)),
-    data = data1
+    data = data1,
+    residuals = TRUE
   )
   
   expect_equal(round(fit$parameters$CL,3), 5.368)
@@ -649,7 +650,12 @@ test_that("Can estimate mixture model", {
   expect_true(!is.null(fit$mixture$probabilities))
   expect_equal(round(fit$mixture$probabilities, 2), c(0.66, 0.34))
   expect_equal(fit$mixture$mixture_group, 1)
-  expect_equal(fit$mixture$selected, 5)  
+  expect_equal(fit$mixture$selected, 5)
+  expect_equal(
+    round(fit$ipred, 2),
+    c(989, 975.78, 949.87, 900.11, 808.27, 725.79, 651.73, 525.52, 
+      277, 669.96, 353.13)
+  )
 })
 
 test_that("MAP fit works with TDM before first dose", {


### PR DESCRIPTION
It was found that the predictions after MAP fitting for mixture models was actually not using the individual parameter (used in the mixture), but rather the population value, since `mixture_group` was passed to `sim()`. This was corrected, and a test was added.