### PR TITLE
better handling of floating points during warning check

### DIFF
--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -550,7 +550,7 @@ get_map_estimates <- function(
     pred <- sim_pred$y
     w_ipred <- sqrt(error$prop[data$obs_type]^2 * transf(ipred)^2 + error$add[data$obs_type]^2)
     w_pred <- sqrt(error$prop[data$obs_type]^2 * transf(pred)^2 + error$add[data$obs_type]^2)
-    if(!(all(data$t == sim_ipred$t) && all(data$obs_type == sim_ipred$obs_type))) {
+    if(!isTRUE(all.equal(data$t, sim_ipred$t)) && all(data$obs_type == sim_ipred$obs_type)) {
       warning("Mismatch in times and observation typese between input data and predictions. Be careful interpreting results from fit.")
     }
     y <- data$y


### PR DESCRIPTION
Requires https://github.com/InsightRX/PKPDsim/pull/121

It is possible to get a mismatch in floating point precision when observations and covariates are at the same time and t_init is also a floating point value.