### PR TITLE
RXR-2719: rm unused argument to PKPD::sim()

### DIFF
--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -228,7 +228,6 @@ get_map_estimates <- function(
       checks = FALSE,
       only_obs = TRUE,
       A_init = A_init,
-      fixed = fixed,
       mixture_group = mixture_group, # dummy value
       t_max = tail(t_obs, 1) + t_init + 1,
       iov_bins = iov_bins,


### PR DESCRIPTION
because we removed the `...` argument in PKPDsim::sim() in [this PR](https://github.com/InsightRX/PKPDsim/pull/125). PKPDmap::get_map_estimates() was still passing an argument that wasn't used. No updates in tests needed, just removal of the unused argument.