### PR TITLE
fix behavior + test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PKPDmap
 Type: Package
 Title: MAP Bayesian estimates
-Version: 1.1.4
-Date: 2025-07-12
+Version: 1.1.5
+Date: 2025-09-09
 Author: Ron Keizer, Jasmine Hughes, Kara Woo
 Maintainer: Ron Keizer <ron@insight-rx.com>
 Description: Obtain MAP Bayesian estimates based on individual data and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PKPDmap
 Type: Package
 Title: MAP Bayesian estimates
-Version: 1.1.5
-Date: 2025-09-09
+Version: 1.1.6
+Date: 2025-09-10
 Author: Ron Keizer, Jasmine Hughes, Kara Woo
 Maintainer: Ron Keizer <ron@insight-rx.com>
 Description: Obtain MAP Bayesian estimates based on individual data and

--- a/R/parse_input_data.R
+++ b/R/parse_input_data.R
@@ -13,6 +13,7 @@ parse_input_data <- function(
   } else {
     data$obs_type <- data[[obs_type_label]]
   }
+  data$OBS_TYPE <- NULL # ensure there is no duplicate `obs_type` column
   colnames(data) <- tolower(colnames(data))
   if(!all(tolower(unlist(cols)) %in% names(data))) {
     stop("Expected column names were not found in data. Please use 'cols' argument to specify column names for independent and dependent variable.")

--- a/tests/testthat/test-parse_input_data.R
+++ b/tests/testthat/test-parse_input_data.R
@@ -1,4 +1,4 @@
-test_that("parse_input_data handles regular data frame input", {
+test_that("parse_input_data handles regular data frame input, with OBS_TYPE label but not specified as `obs_type_label`", {
   # Create test data
   data <- data.frame(
     T = c(2, 1, 3),
@@ -6,15 +6,36 @@ test_that("parse_input_data handles regular data frame input", {
     Y = c(10, 20, 30)
   )
   
-  result <- parse_input_data(data)
+  result <- parse_input_data(data, obs_type_label = NULL)
   
   # Check column names are lowercase
-  expect_equal(names(result), c("t", "obs_type", "y", "obs_type"))
+  expect_equal(names(result), c("t", "y", "obs_type"))
+  
+  # Check sorting
+  expect_equal(result$t, c(1, 2, 3))
+  expect_equal(result$obs_type, c(1, 1, 1))
+
+})
+
+test_that("parse_input_data handles regular data frame input, with OBS_TYPE label, properly specified as `obs_type_label`", {
+  # Create test data
+  data <- data.frame(
+    T = c(2, 1, 3),
+    OBS_TYPE = c(2, 1, 1),
+    Y = c(10, 20, 30)
+  )
+  
+  result <- parse_input_data(data, obs_type_label = "OBS_TYPE")
+  
+  # Check column names are lowercase
+  expect_equal(names(result), c("t", "y", "obs_type"))
   
   # Check sorting
   expect_equal(result$t, c(1, 2, 3))
   expect_equal(result$obs_type, c(1, 2, 1))
+  
 })
+
 
 test_that("parse_input_data handles PKPDsim object", {
   # Create mock PKPDsim object

--- a/tests/testthat/test-parse_input_data.R
+++ b/tests/testthat/test-parse_input_data.R
@@ -17,6 +17,18 @@ test_that("parse_input_data handles regular data frame input, with OBS_TYPE labe
 
 })
 
+test_that("parse_input_data picks right column, even with lower/uppercase duplicates", {
+  data <- data.frame(
+    T = c(1, 2, 3),
+    obs_type = c(1, 0, 1),
+    OBS_TYPE = c(2, 1, 1),
+    Y = c(10, 20, 30)
+  )
+  result <- parse_input_data(data, obs_type_label = "OBS_TYPE")
+  expect_equal(result$obs_type, c(2, 1, 1))
+  expect_equal(sum(tolower(names(result)) == "obs_type"), 1)
+})
+
 test_that("parse_input_data handles regular data frame input, with OBS_TYPE label, properly specified as `obs_type_label`", {
   # Create test data
   data <- data.frame(


### PR DESCRIPTION
This fixes the edge case where it was possible to have duplicate `obs_type` columns in the return object from `parse_input_data()`. 

It's still a bit ugly to have a specific line of code to set OBS_TYPE to NULL to avoid an edge case, but I think this is the simplest solution. The other solution is to not care about the edge case (it essentially only occurs with erroneous usage).

Very minor change, shouldn't affect any production code.