### PR TITLE
RXR-3044: remove `...` from `get_map_estimates()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,6 @@ Depends: utils, stats
 Imports: PKPDsim, numDeriv, mvtnorm
 Suggests: testthat (>= 3.0.0)
 Remotes: InsightRX/PKPDsim
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8
 Config/testthat/edition: 3

--- a/R/calc_residuals.R
+++ b/R/calc_residuals.R
@@ -32,8 +32,7 @@ calc_residuals <- function(
   censoring = NULL,
   censoring_idx = NULL,
   data_before_init = NULL,
-  ltbs = FALSE,
-  ...
+  ltbs = FALSE
 ) {
 
   ## Observation vectors
@@ -61,8 +60,7 @@ calc_residuals <- function(
       iov_bins = iov_bins,
       output_include = output_include,
       t_init = t_init,
-      lagtime = lagtime,
-      ...
+      lagtime = lagtime
     )
   })
   suppressMessages({
@@ -81,8 +79,7 @@ calc_residuals <- function(
       iov_bins = iov_bins,
       A_init = A_init_population,
       t_init = t_init,
-      lagtime = lagtime,
-      ...
+      lagtime = lagtime
     )
   })
 

--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -61,8 +61,7 @@
 #'option is `TRUE`.
 #' @param skip_hessian skip calculation of Hessian
 #' @param verbose show more output
-#' @param ... parameters passed on to `sim_ode()` function
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' ## define parameters
@@ -134,8 +133,7 @@ get_map_estimates <- function(
                       verbose = FALSE,
                       A_init = NULL,
                       skip_hessian = FALSE,
-                      output_include = list(covariates = FALSE, parameters = FALSE),
-                      ...) {
+                      output_include = list(covariates = FALSE, parameters = FALSE)) {
 
   ## get prior weight for scaling of variance term
   weight_prior_var <- parse_weight_prior(weight_prior, type)
@@ -232,8 +230,7 @@ get_map_estimates <- function(
       t_max = tail(t_obs, 1) + t_init + 1,
       iov_bins = iov_bins,
       return_design = TRUE,
-      t_init = t_init,
-      ...
+      t_init = t_init
     )
   })
 
@@ -426,8 +423,7 @@ get_map_estimates <- function(
       censoring = censoring,
       censoring_idx = censoring_idx,
       data_before_init = data_before_init,
-      ltbs = ltbs,
-      ...
+      ltbs = ltbs
     )
   }
   

--- a/man/calc_residuals.Rd
+++ b/man/calc_residuals.Rd
@@ -26,8 +26,7 @@ calc_residuals(
   censoring = NULL,
   censoring_idx = NULL,
   data_before_init = NULL,
-  ltbs = FALSE,
-  ...
+  ltbs = FALSE
 )
 }
 \arguments{
@@ -83,8 +82,6 @@ in this column is < 0 then censoring is assumed <LLOQ. If > 0 then  >ULOQ.}
 \item{ltbs}{log-transform both sides? (`NULL` by default, meaning that it 
 will be picked up from the PKPDsim model. Can be overridden with `TRUE`). 
 Note: `error` should commonly only have additive part.}
-
-\item{...}{parameters passed on to `sim_ode()` function}
 }
 \description{
 Function to calculate residuals from a fit,

--- a/man/get_map_estimates.Rd
+++ b/man/get_map_estimates.Rd
@@ -38,8 +38,7 @@ get_map_estimates(
   verbose = FALSE,
   A_init = NULL,
   skip_hessian = FALSE,
-  output_include = list(covariates = FALSE, parameters = FALSE),
-  ...
+  output_include = list(covariates = FALSE, parameters = FALSE)
 )
 }
 \arguments{
@@ -137,8 +136,6 @@ will be slightly slower.}
 \item{output_include}{passed to PKPDsim::sim_ode(), returns covariates and
 parameter values over time in return object. Only invoked if `residuals` 
 option is `TRUE`.}
-
-\item{...}{parameters passed on to `sim_ode()` function}
 }
 \description{
 Get MAP estimates

--- a/man/map_shrinkage_control.Rd
+++ b/man/map_shrinkage_control.Rd
@@ -22,8 +22,6 @@ all parameters).}
 \item{fixed}{fix a specific parameters, supplied as vector of strings}
 
 \item{data}{data data.frame with columns `t` and `y` (and possibly evid)}
-
-\item{...}{parameters passed on to `sim_ode()` function}
 }
 \description{
 Limits the amount of individual shrinkage to a certain specified number


### PR DESCRIPTION
As a follow-up to https://github.com/InsightRX/PKPDsim/pull/125 we want to remove `...` from `get_map_estimates()` as well, since this was passed to `PKPDsim::sim()`.

Marking this as a draft right now. Will mark as ready for review after I've pushed PRs for other packages where we call this function with `...`, and tested the consequences of this change in other packages that call `PKPDmap::get_map_estimates()` more generally.