### PR TITLE
RXR-3163: minimal change to undo breaking change in PR#59

### DIFF
--- a/R/get_map_estimates.R
+++ b/R/get_map_estimates.R
@@ -299,10 +299,6 @@ get_map_estimates <- function(
       likelihood = like
     )
   } else {
-    # When residuals=TRUE, the FOCE Jacobian computed in calc_residuals
-    # provides both CWRES and the Hessian/vcov, so we can skip the more
-    # expensive numDeriv::hessian here.
-    skip_hessian_mle <- skip_hessian || residuals
     output <- tryCatch({
       fit <- mle_wrapper(
         ll_func,
@@ -310,7 +306,7 @@ get_map_estimates <- function(
         method = method,
         optimizer = optimizer,
         control = control,
-        skip_hessian = skip_hessian_mle,
+        skip_hessian = skip_hessian,
         data = list(
           data = data,
           sim_object = sim_object,
@@ -436,14 +432,11 @@ get_map_estimates <- function(
   }
   
   ## Add variance-covariance matrix to output object.
-  ## When residuals were computed, the FOCE vcov from the Jacobian is
-  ## preferred over numDeriv::hessian (faster, same FOCE approximation).
-  vcov_source <- obj$fit$vcov
-  if (!is.null(obj$foce_vcov)) {
-    vcov_source <- obj$foce_vcov
-  }
+  ## foce_vcov (computed from the FOCE Jacobian) is stored for diagnostics
+  ## but not used as the primary vcov source — it has known issues with
+  ## observation weights and proportional error that need to be fixed first.
   obj$vcov_full <- get_varcov_matrix(
-    vcov_source,
+    obj$fit$vcov,
     fallback = omega$full
   )
   if(inherits(obj$vcov_full, "matrix")) {

--- a/tests/testthat/test-get_map_estimates.R
+++ b/tests/testthat/test-get_map_estimates.R
@@ -596,6 +596,7 @@ test_that("FOCE vcov is positive definite even when numDeriv Hessian would fail"
   expect_false(is.null(fit$foce_vcov))
   expect_true(PKPDsim::is_positive_definite(fit$foce_vcov))
   expect_true(PKPDsim::is_positive_definite(fit$vcov_full))
+  skip("Skipping until weights are added to FOCE")
   expect_equal(fit$vcov_full, fit$foce_vcov)
 })
 


### PR DESCRIPTION
In https://github.com/InsightRX/PKPDmap/pull/59, we inadvertently introduced an issue so that obj$vcov_full sometimes had a different value, when we expected it to have parity from before.

This PR minimally reverts some of the changes made in that PR so that we continue to use the (slow) numDeriv::hessian as before, rather than the FOCE VCOV.

Fixes necessary to get the FOCE VCOV up to snuff will be made in a separate PR.